### PR TITLE
Add timeout configuration on fetching of region server logs.

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -24,7 +24,7 @@ object Global extends GlobalSettings {
         logLevelUrlPattern = app.configuration.getString("compactions.loglevel-url-pattern").get,
         logFileUrlPattern = app.configuration.getString("compactions.logfile-url-pattern").get,
         logFileDateFormat = app.configuration.getString("compactions.logfile-date-format").get,
-        logFetchTimeout =  app.configuration.getInt("compactions.logfile.fetch.timeout.in.seconds").get
+        logFetchTimeout =  app.configuration.getInt("compactions.logfile-fetch-timeout-in-seconds").get
       )
 
       val updateMetricsActor = Akka.system.actorOf(Props[UpdateMetricsActor], name = "updateMetricsActor")

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -23,7 +23,8 @@ object Global extends GlobalSettings {
         setLogLevelsOnStartup = app.configuration.getBoolean("compactions.set-loglevels-on-startup") == Some(true),
         logLevelUrlPattern = app.configuration.getString("compactions.loglevel-url-pattern").get,
         logFileUrlPattern = app.configuration.getString("compactions.logfile-url-pattern").get,
-        logFileDateFormat = app.configuration.getString("compactions.logfile-date-format").get
+        logFileDateFormat = app.configuration.getString("compactions.logfile-date-format").get,
+        logFetchTimeout =  app.configuration.getInt("compactions.logfile.fetch.timeout.in.seconds").get
       )
 
       val updateMetricsActor = Akka.system.actorOf(Props[UpdateMetricsActor], name = "updateMetricsActor")

--- a/app/models/Compaction.scala
+++ b/app/models/Compaction.scala
@@ -18,6 +18,7 @@ object Compaction extends HBaseConnection {
 
   val COMPACTION = """(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)sec""".r
 
+  var logFetchTimeout: Int = 5
   var logFileUrlPattern: String = null
   var logLevelUrlPattern: String = null
   var setLogLevelsOnStartup: Boolean = false
@@ -26,11 +27,13 @@ object Compaction extends HBaseConnection {
   def configure(setLogLevelsOnStartup: Boolean = false,
                 logFileUrlPattern: String = null,
                 logLevelUrlPattern: String = null,
-                logFileDateFormat: String = null) = {
+                logFileDateFormat: String = null,
+                logFetchTimeout: Int = 5) = {
     this.setLogLevelsOnStartup = setLogLevelsOnStartup
     this.logFileUrlPattern = logFileUrlPattern
     this.logLevelUrlPattern = logLevelUrlPattern
     this.logFileDateFormat = new java.text.SimpleDateFormat(logFileDateFormat)
+    this.logFetchTimeout = logFetchTimeout
   }
 
   def init() = {
@@ -61,7 +64,7 @@ object Compaction extends HBaseConnection {
       (hbaseAdmin, clusterStatus, serverName) =>
         val url = logFileUrl(serverName)
         Logger.debug("... fetching Logfile from " + url)
-        val response = WS.url(url).get().value.get
+        val response = WS.url(url).get().await(logFetchTimeout * 1000).get
         if (response.ahcResponse.getStatusCode() != 200) {
           throw new Exception("couldn't load Compaction Metrics from URL: '" +
             url + "', please check compactions.logfile_pattern in application.conf");

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,4 +54,4 @@ compactions.set-loglevels-on-startup = false
 compactions.loglevel-url-pattern = "http://%hostname%:60030/logLevel?log=org.apache.hadoop.hbase&level=INFO"
 compactions.logfile-url-pattern = "http://%hostname%:60030/logs/hbase-cmf-hbase1-REGIONSERVER-%hostname%.log.out"
 compactions.logfile-date-format = "yyyy-MM-dd HH:mm:ss,SSS"
-compactions.logfile.fetch.timeout.in.seconds=60
+compactions.logfile-fetch-timeout-in-seconds=5

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,3 +54,4 @@ compactions.set-loglevels-on-startup = false
 compactions.loglevel-url-pattern = "http://%hostname%:60030/logLevel?log=org.apache.hadoop.hbase&level=INFO"
 compactions.logfile-url-pattern = "http://%hostname%:60030/logs/hbase-cmf-hbase1-REGIONSERVER-%hostname%.log.out"
 compactions.logfile-date-format = "yyyy-MM-dd HH:mm:ss,SSS"
+compactions.logfile.fetch.timeout.in.seconds=60


### PR DESCRIPTION
I've been running hannibal locally against one of our clusters and getting the region server log files takes longer than 5 seconds...which is the implicit default timeout. Here are changes to make this configurable. 
