### PR TITLE
Make the compaction log fetching smarter and less memory hungry

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -24,13 +24,14 @@ object Global extends GlobalSettings {
         logLevelUrlPattern = app.configuration.getString("compactions.loglevel-url-pattern").get,
         logFileUrlPattern = app.configuration.getString("compactions.logfile-url-pattern").get,
         logFileDateFormat = app.configuration.getString("compactions.logfile-date-format").get,
-        logFetchTimeout =  app.configuration.getInt("compactions.logfile-fetch-timeout-in-seconds").get
+        logFetchTimeout =  app.configuration.getInt("compactions.logfile-fetch-timeout-in-seconds").get,
+        initialLookBehindSizeInKBs =  app.configuration.getInt("compactions.logfile-initial-look-behind-size-in-kb").get
       )
 
       val updateMetricsActor = Akka.system.actorOf(Props[UpdateMetricsActor], name = "updateMetricsActor")
       Akka.system.scheduler.schedule(0 seconds, 60 seconds, updateMetricsActor, UpdateMetricsActor.UPDATE_REGION_INFO_METRICS)
       Akka.system.scheduler.scheduleOnce(15 seconds, updateMetricsActor, UpdateMetricsActor.INIT_COMPACTION_METRICS)
-      Akka.system.scheduler.schedule(30 seconds, 600 seconds, updateMetricsActor, UpdateMetricsActor.UPDATE_COMPACTION_METRICS)
+      Akka.system.scheduler.schedule(30 seconds, 300 seconds, updateMetricsActor, UpdateMetricsActor.UPDATE_COMPACTION_METRICS)
       Akka.system.scheduler.schedule(90 seconds, 1 days, updateMetricsActor, UpdateMetricsActor.CLEAN_OLD_METRICS)
 
     } else {

--- a/app/models/Compaction.scala
+++ b/app/models/Compaction.scala
@@ -6,16 +6,20 @@ package models
 
 import play.api.Logger
 import org.apache.hadoop.hbase.ServerName
-import play.api.libs.ws.WS
+import play.api.libs.ws.{Response, WS}
 import collection.mutable.MutableList
 import java.util.Date
 import utils.HBaseConnection
 import java.text.SimpleDateFormat
 import java.util.regex._
+import collection.mutable
+import play.api.libs.concurrent.NotWaiting
+import org.apache.commons.lang.StringUtils
 
 case class Compaction(region: String, start: Date, end: Date)
 
 object Compaction extends HBaseConnection {
+  val NEWLINE = "\n".getBytes("UTF-8")(0)
 
   val COMPACTION = Pattern.compile(
     """^(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)$""",
@@ -24,21 +28,25 @@ object Compaction extends HBaseConnection {
   val TIME = Pattern.compile("""^((\d+)mins, )?((\d+)sec)$""")
 
   var logFetchTimeout: Int = 5
+  var initialLogLookBehindSizeInKBs: Long = 1024
   var logFileUrlPattern: String = null
   var logLevelUrlPattern: String = null
   var setLogLevelsOnStartup: Boolean = false
   var logFileDateFormat: SimpleDateFormat = null
+  var logOffsets = mutable.Map.empty[ServerName, Long]
 
   def configure(setLogLevelsOnStartup: Boolean = false,
                 logFileUrlPattern: String = null,
                 logLevelUrlPattern: String = null,
                 logFileDateFormat: String = null,
-                logFetchTimeout: Int = 5) = {
+                logFetchTimeout: Int = 5,
+                initialLookBehindSizeInKBs: Long = 1024) = {
     this.setLogLevelsOnStartup = setLogLevelsOnStartup
     this.logFileUrlPattern = logFileUrlPattern
     this.logLevelUrlPattern = logLevelUrlPattern
     this.logFileDateFormat = new java.text.SimpleDateFormat(logFileDateFormat)
     this.logFetchTimeout = logFetchTimeout
+    this.initialLogLookBehindSizeInKBs = initialLogLookBehindSizeInKBs
   }
 
   def init() = {
@@ -70,14 +78,33 @@ object Compaction extends HBaseConnection {
         try
         {
           val url = logFileUrl(serverName)
-          Logger.debug("... fetching Logfile from " + url)
-          val response = WS.url(url).get().await(logFetchTimeout * 1000).get
-          if (response.ahcResponse.getStatusCode() != 200) {
-            throw new Exception("couldn't load Compaction Metrics from URL: '" +
-              url + "', please check compactions.logfile_pattern in application.conf");
+          if (!logOffsets.contains(serverName)) {
+            val headValue: NotWaiting[Response] = WS.url(url).head().value
+            val logLength = headValue.get.header("Content-Length").get.toLong
+            val offset = scala.math.max(0, logLength - initialLogLookBehindSizeInKBs * 1024)
+            Logger.info("Initializing log offset to [%d] for log file at %s with content-length [%d]".format(offset, url, logLength))
+            logOffsets(serverName) = offset
           }
 
-          val m = COMPACTION.matcher(response.body);
+          var response: Response = recentLogContent(url, serverName, logOffsets(serverName))
+
+          val contentRange = response.getAHCResponse.getHeader("Content-Range")
+          val rangeValue = StringUtils.substringBetween(contentRange, "bytes", "/").trim()
+          if (rangeValue eq "*") {
+            // The offset doesn't match the file content because, presumably, of log file rotation,
+            // reset the offset to 0
+            logOffsets(serverName) = 0l
+            Logger.info("Log file [%s] seems to have rotated, resetting offset to 0".format(url))
+            response = recentLogContent(url, serverName, logOffsets(serverName))
+          } else {
+            // Set the next offset to the base offset + the offset matching the last newline found
+            logOffsets(serverName) = logOffsets(serverName) + offsetOfLastNewline(response.body)
+
+            Logger.debug("Updating logfile offset to [%d] for server [%s]".
+              format(logOffsets(serverName), serverName.getServerName))
+          }
+ 
+          val m = COMPACTION.matcher(response.body)
           while(m.find()) {
             val date = m.group(1)
             val pkg = m.group(2)
@@ -104,6 +131,29 @@ object Compaction extends HBaseConnection {
         }
     }
     resultList.toList
+  }
+
+  def offsetOfLastNewline(body: String):Long = {
+    val bytes: Array[Byte] = body.getBytes
+
+    for (i <- bytes.length - 1 to  0 by -1) {
+      if (bytes(i) == NEWLINE) {
+        return i
+      }
+    }
+
+    0
+  }
+
+  def recentLogContent(url: String, serverName: ServerName, offset: Long) = {
+    Logger.debug("... fetching Logfile from %s with range [%d-]".format(url, offset))
+    val response = WS.url(url).withHeaders(("Range", "bytes=%d-".format(offset))).get().await(logFetchTimeout * 1000).get
+    if (!List(200, 206).contains(response.ahcResponse.getStatusCode)) {
+      throw new Exception("couldn't load Compaction Metrics from URL: '" +
+        url + "', please check compactions.logfile_pattern in application.conf")
+    }
+
+    response
   }
 
   def parseDuration(s:String) = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,3 +60,7 @@ compactions.logfile-fetch-timeout-in-seconds=30
 compactions.loglevel-url-pattern = ${?HANNIBAL_COMPACTIONS_LOGLEVEL_URL_PATTERN}
 compactions.logfile-url-pattern = ${?HANNIBAL_COMPACTIONS_LOGFILE_URL_PATTERN}
 compactions.logfile-date-format = ${?HANNIBAL_COMPACTIONS_LOGFILE_DATE_FORMAT}
+
+# Set this to a higher value if you want the first log fetching to look farther back to get more compaction data
+# (at the cost of higher memory usage and latency)
+compactions.logfile-initial-look-behind-size-in-kb=1024


### PR DESCRIPTION
Instead of fetching the complete region server log file (which can be
in the hundreds of MBs), we now initially look back only 1024 KBs prior to
the end of the file. Each subsequent refresh of the compaction metrics
starts at the offset of the last new line of the previous fetch. This
makes each fetch of the compaction logs faster and lowers the memory
requirement to keep the content in memory for parsing.
