### PR TITLE
Replace log file url pattern configuration by a regex-based discovery of that pattern (issue #11)

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -23,7 +23,7 @@ object Global extends GlobalSettings {
       LogFile.configure(
         setLogLevelsOnStartup = app.configuration.getBoolean("compactions.set-loglevels-on-startup") == Some(true),
         logLevelUrlPattern = app.configuration.getString("compactions.loglevel-url-pattern").get,
-        logFileUrlPattern = app.configuration.getString("compactions.logfile-url-pattern").get,
+        logFilePathPattern = app.configuration.getString("compactions.logfile-path-pattern").get,
         logFileDateFormat = app.configuration.getString("compactions.logfile-date-format").get,
         logFetchTimeout =  app.configuration.getInt("compactions.logfile-fetch-timeout-in-seconds").get,
         initialLookBehindSizeInKBs =  app.configuration.getInt("compactions.logfile-initial-look-behind-size-in-kb").get
@@ -32,7 +32,6 @@ object Global extends GlobalSettings {
       val updateMetricsActor = Akka.system.actorOf(Props[UpdateMetricsActor], name = "updateMetricsActor")
       Akka.system.scheduler.schedule(0 seconds, 60 seconds, updateMetricsActor, UpdateMetricsActor.UPDATE_REGION_INFO_METRICS)
       Akka.system.scheduler.scheduleOnce(15 seconds, updateMetricsActor, UpdateMetricsActor.INIT_COMPACTION_METRICS)
-      Akka.system.scheduler.schedule(30 seconds, 300 seconds, updateMetricsActor, UpdateMetricsActor.UPDATE_COMPACTION_METRICS)
       Akka.system.scheduler.schedule(90 seconds, 1 days, updateMetricsActor, UpdateMetricsActor.CLEAN_OLD_METRICS)
 
     } else {

--- a/app/models/LogFile.scala
+++ b/app/models/LogFile.scala
@@ -11,7 +11,8 @@ import play.api.libs.concurrent.NotWaiting
 import org.apache.commons.lang.StringUtils
 import models.LogFile._
 import collection.mutable.ListBuffer
-import java.text.SimpleDateFormat
+import scala.util.control.Breaks._
+import java.util.regex._
 
 case class LogFile(regionServer:RegionServer) {
 
@@ -52,7 +53,7 @@ case class LogFile(regionServer:RegionServer) {
     val response = WS.url(url).withHeaders(("Range", "bytes=%d-".format(offset))).get().await(logFetchTimeout * 1000).get
     if (!List(200, 206).contains(response.ahcResponse.getStatusCode)) {
       throw new Exception("couldn't load Compaction Metrics from URL: '" +
-        url + "', please check compactions.logfile_pattern in application.conf")
+        url + "', please check compactions.logfile-path-pattern in application.conf")
     }
 
     response
@@ -76,6 +77,7 @@ object LogFile {
   private var logFetchTimeout: Int = 5
   private var initialLogLookBehindSizeInKBs: Long = 1024
   private var logFileUrlPattern: String = null
+  private var logFilePathPattern: Pattern = null
   private var logLevelUrlPattern: String = null
   private var setLogLevelsOnStartup: Boolean = false
   private var logFileDateFormat: SimpleDateFormat = null
@@ -84,20 +86,45 @@ object LogFile {
   val NEWLINE = "\n".getBytes("UTF-8")(0)
 
   def configure(setLogLevelsOnStartup: Boolean = false,
-                logFileUrlPattern: String = null,
                 logLevelUrlPattern: String = null,
+                logFilePathPattern: String = null,
                 logFileDateFormat: String = null,
                 logFetchTimeout: Int = 5,
                 initialLookBehindSizeInKBs: Long = 1024) = {
     this.setLogLevelsOnStartup = setLogLevelsOnStartup
-    this.logFileUrlPattern = logFileUrlPattern
     this.logLevelUrlPattern = logLevelUrlPattern
+    this.logFilePathPattern = Pattern.compile(logFilePathPattern)
     this.logFileDateFormat = new java.text.SimpleDateFormat(logFileDateFormat)
     this.logFetchTimeout = logFetchTimeout
     this.initialLogLookBehindSizeInKBs = initialLogLookBehindSizeInKBs
   }
 
-  def init() = {
+  def discoverLogFileUrlPattern = {
+    var logFilePattern: String  = null
+    breakable {
+      HBase.eachRegionServer {
+        regionServer =>
+          val url = logRootUrl(regionServer)
+          val response = WS.url(url).get().value.get
+          val logFileMatcher = logFilePathPattern.matcher(response.body)
+
+          if (logFileMatcher.find()) {
+            val path = logFileMatcher.group(1)
+            // We assume that all region servers use the same pattern so once we've got the pattern for one of them,
+            // we stop
+            Logger.info("Found path matching compactions.logfile-path-pattern: %s".format(path))
+            logFilePattern = (url + path).replaceAll(regionServer.hostName, "%hostname%")
+              .replaceAll(regionServer.infoPort.toString, "%infoport%")
+              .replaceAll(regionServer.hostName.split("\\.")(0), "%hostname-without-domain%")
+            break()
+          }
+      }
+    }
+
+    logFilePattern
+  }
+
+  def init() {
     if (setLogLevelsOnStartup) {
       Logger.info("setting Loglevels for the Regionservers")
       HBase.eachRegionServer {
@@ -111,6 +138,9 @@ object LogFile {
           }
       }
     }
+
+    logFileUrlPattern = discoverLogFileUrlPattern
+    Logger.info("Discovered log file url pattern: [%s]".format(logFileUrlPattern))
   }
 
   def all() = {
@@ -129,4 +159,6 @@ object LogFile {
   def logFileUrl(regionServer: RegionServer) = regionServer.infoUrl(logFileUrlPattern)
 
   def logLevelUrl(regionServer: RegionServer) = regionServer.infoUrl(logLevelUrlPattern)
+
+  def logRootUrl(regionServer: RegionServer) = regionServer.infoUrl("http://%hostname%:%infoport%/logs/")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,7 +52,9 @@ akka.actor.debug.receive = on
 # Set HBase Regionserver LogLevel to INFO which is required for Compaction-Metrics
 compactions.set-loglevels-on-startup = false
 compactions.loglevel-url-pattern = "http://%hostname%:%infoport%/logLevel?log=org.apache.hadoop.hbase&level=INFO"
-compactions.logfile-url-pattern = "http://%hostname%:%infoport%/logs/hbase-hbase-regionserver-%hostname%.log"
+# This is the pattern to match a region server logfile as listed in the html body when hitting
+# http://%hostname%:%infoport%/logs/
+compactions.logfile-path-pattern = "(?i)\"/logs/(.*regionserver.*[.].*)\""
 compactions.logfile-date-format = "yyyy-MM-dd HH:mm:ss,SSS"
 compactions.logfile-fetch-timeout-in-seconds=30
 


### PR DESCRIPTION
So this works like this:
- compactions.logfile-path-pattern defines the regex for a region server log file.
- on init(), we now iterate over region servers to discover the main log file that matches the regex. On first match, we build the logFileUrlPattern by replacing the current region server's attributes by the tokens (same as before). 
- once we've got the logFileUrlPattern, everything works as it used to

I've also jammed into this change a rearrangement of the way the compaction metrics is scheduled. Instead of having the init and update be completely disjoint, the init now schedules the update (my reasoning is that the update needs the init to have happened first, especially now). Also, to prevent updates from piling up on top of each other (imagine an update that would take longer than the interval between refreshes), an update schedules the next one as it completes. I'm hoping that having put the scheduling of the next update in a finally block will address concerns that we might have an update that fails causing that feature from stopping.
