### PR TITLE
Cloudera's Maven needs https now, otherwise build will fail. 

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,7 @@ object ApplicationBuild extends Build {
     })
 
     val appResolvers = Seq(
-      "Cloudera Public Repository" at "http://repository.cloudera.com/artifactory/cloudera-repos/",
+      "Cloudera Public Repository" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
       "Mockito Core" at "http://repo2.maven.org/maven2/org/mockito/mockito-core",
       "Mockito All" at "http://repo2.maven.org/maven2/org/mockito/mockito-all"
     ) 


### PR DESCRIPTION
SBT must use Cloudera's https repo to avoid a redirect, if https is not
used, than sbt will fail to build.
