### PR TITLE
Handle non printable characters in region names

### DIFF
--- a/app/views/regions/index.scala.html
+++ b/app/views/regions/index.scala.html
@@ -4,7 +4,7 @@
 
 <ul>
 	@regionList.map { region =>
-	<li><a href="@routes.Regions.show(java.net.URLEncoder.encode(region.regionName, "UTF-8"))">@region.regionName</a></li> }
+	<li><a href="@routes.Regions.show(java.net.URLEncoder.encode(region.regionURI, "UTF-8"))">@region.regionName</a></li> }
 </ul>
 
 } { } {


### PR DESCRIPTION
Handling regions names with non printable characters caused Hannibal
to print question marks and not route to correct region details.

This fixes #20.
