### PR TITLE
Add Defaulting of hbase Configuration to the System Config.

### DIFF
--- a/create_package
+++ b/create_package
@@ -46,7 +46,12 @@ echo 'echo "starting Hannibal for HBase '$HANNIBAL_HBASE_VERSION' on Port 9000 (
 echo 'else' >> $temp_dir/hannibal/start
 echo 'echo "starting Hannibal for HBase '$HANNIBAL_HBASE_VERSION' on Port $HANNIBAL_HTTP_PORT (as defined by HANNIBAL_HTTP_PORT)"' >> $temp_dir/hannibal/start
 echo 'fi' >> $temp_dir/hannibal/start
-echo 'exec java -DapplyEvolutions.default=true -Dhttp.port=$HANNIBAL_HTTP_PORT -cp "`dirname $0`/conf:`dirname $0`/target/staged/*" play.core.server.NettyServer `dirname $0`' >> $temp_dir/hannibal/start
+echo 'HBASE_CLASSPATH=`hbase classpath`' >> $temp_dir/hannibal/start
+echo '# Only use the hbase classpath if the command is available and ran successfully' >> $temp_dir/hannibal/start
+echo 'if [ $? -ne 0 ]; then' >> $temp_dir/hannibal/start
+echo '  HBASE_CLASSPATH=""' >> $temp_dir/hannibal/start
+echo 'fi' >> $temp_dir/hannibal/start
+echo 'exec java -DapplyEvolutions.default=true -Dhttp.port=$HANNIBAL_HTTP_PORT -cp "`dirname $0`/conf:`dirname $0`/target/staged/*:$HBASE_CLASSPATH" play.core.server.NettyServer `dirname $0`' >> $temp_dir/hannibal/start
 
 pkgname=hannibal-hbase$HANNIBAL_HBASE_VERSION.tgz
 echo "4. create package: $pkgname ..."


### PR DESCRIPTION
Update the create_package script so that the hannibal startup
script gets the hbase configuration from the system it is
running from using 'hbase classpath'. This allows hannibal to be
installed without manual hbase-site.xml copying/editing
on a gateway node that has the target hbase cluster configuration.

In a case where the 'hbase shell' command is not available,
we get the same behavior as before. Also note that a configuration
file present in conf/hbase-site.xml should override the hbase
system configuration since it's before in the classpath.
