### PR TITLE
ability to configure/override regex pattern for parsing compaction me…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -163,6 +163,13 @@ if this is the case, you can set the regex pattern via this variable
 example:
 logfileParser.overrideCompactionRegexPattern="""^(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)$"""
 
+Also set the positions of the date/region/duration groups in the above regex via the following parameters:
+
+logfileParser.dateGroupPosition=1
+logfileParser.regionGroupPosition=3
+logfileParser.durationGroupPosition=9
+
+i.e. date occurs as the first group, region as the third group and duration as the ninth group in the above example regex pattern
 
 ## Tuning for large clusters
 Hannibal is not yet ready to be used on large clusters (say about more than 100 machines), however some work has been done (thanks to [Alexandre Normand][] and [churrodog][]) to make it at least possible to run it without crashing on mid-sized clusters. If Hannibal's performance is not sufficient with your HBase setup, it may help to tune the following parameters in [conf/application.conf][].

--- a/README.markdown
+++ b/README.markdown
@@ -154,6 +154,15 @@ and set
     logfile.set-loglevels-on-startup = true
 If this doesn't work for you, you should try to manually change the loglevel on your regionservers.
 
+### 4. logfileParser.overrideCompactionRegexPattern
+
+Hannibal has been already been configured to look for the INFO message containing compaction metrics (with some default regex patterns depending on the version of hbase.)
+Some times the INFO message logged might not match with the default regex pattern(maybe its different distribution of base), which would result in you not being able to see the compaction metrics.
+
+if this is the case, you can set the regex pattern via this variable
+example:
+logfileParser.overrideCompactionRegexPattern="""^(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)$"""
+
 
 ## Tuning for large clusters
 Hannibal is not yet ready to be used on large clusters (say about more than 100 machines), however some work has been done (thanks to [Alexandre Normand][] and [churrodog][]) to make it at least possible to run it without crashing on mid-sized clusters. If Hannibal's performance is not sufficient with your HBase setup, it may help to tune the following parameters in [conf/application.conf][].

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -5,6 +5,7 @@
 import models.hbase.HBaseContext
 import play.api._
 import actors.UpdateMetricsActor
+import java.util.regex.Pattern
 
 object Global extends GlobalSettings {
 
@@ -20,6 +21,13 @@ object Global extends GlobalSettings {
         try {
           Logger.debug("Try to intanciate api-wrapper %s".format(hbaseContext));
           globals.hBaseContext = Class.forName(hbaseContext).newInstance.asInstanceOf[HBaseContext]
+          val overrideCompactionRegex = app.configuration.getString("logfileParser.overrideCompactionRegexPattern").getOrElse("")
+          if(!Option(overrideCompactionRegex).getOrElse("").isEmpty){
+            //override regex  pattern for compaction metric has been set by user
+            val overrideRegexPattern = Pattern.compile(overrideCompactionRegex,Pattern.MULTILINE)
+            globals.hBaseContext.logFileParser.setOverrideCopactionRegexPattern(overrideRegexPattern)
+            Logger.info("Setting regex pattern for Compaction metrics in logFileParser as [%s]".format(overrideRegexPattern.pattern()))
+          }
         } catch {
           case e: java.lang.ClassNotFoundException =>
             Logger.debug("Instanciating api-wrapper %s failed ".format(hbaseContext));

--- a/app/models/hbase/LogFileParser.scala
+++ b/app/models/hbase/LogFileParser.scala
@@ -16,6 +16,12 @@ trait LogFileParser {
 
   def setOverrideCopactionRegexPattern(pattern: Pattern): Unit
 
+  def setDateGroupPosition(pos: Int): Unit
+
+  def setRegionGroupPosition(pos: Int): Unit
+
+  def setDurationGroupPosition(pos: Int): Unit
+
   def parseDuration(s:String) = {
     val m = TIME.matcher(s)
     m.find()

--- a/app/models/hbase/LogFileParser.scala
+++ b/app/models/hbase/LogFileParser.scala
@@ -14,6 +14,8 @@ trait LogFileParser {
 
   def eachCompaction(logFile: LogFile, functionBlock: (String, Date, Long) => Unit)
 
+  def setOverrideCopactionRegexPattern(pattern: Pattern): Unit
+
   def parseDuration(s:String) = {
     val m = TIME.matcher(s)
     m.find()

--- a/hbase/0.90/scala/models/hbase090/LogFileParser090.scala
+++ b/hbase/0.90/scala/models/hbase090/LogFileParser090.scala
@@ -15,9 +15,9 @@ class LogFileParser090 extends LogFileParser {
     """^(.*) INFO (.*).HRegion: completed compaction on region (.*\.) after (.*)$""",
     Pattern.MULTILINE
   )
-  val DATE_GROUP = 1
-  val REGION_GROUP = 3
-  val DURATION_GROUP = 4
+  var DATE_GROUP = 1
+  var REGION_GROUP = 3
+  var DURATION_GROUP = 4
 
   override def eachCompaction(logFile: LogFile, functionBlock: (String, Date, Long) => Unit) = {
     val m = COMPACTION.matcher(logFile.tail())
@@ -35,6 +35,18 @@ class LogFileParser090 extends LogFileParser {
 
   override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
     COMPACTION = pattern
+  }
+
+  override def setDateGroupPosition(pos: Int): Unit = {
+    DATE_GROUP = pos
+  }
+
+  override def setRegionGroupPosition(pos: Int): Unit = {
+    REGION_GROUP = pos
+  }
+
+  override def setDurationGroupPosition(pos: Int): Unit = {
+    DURATION_GROUP = pos
   }
 
 }

--- a/hbase/0.90/scala/models/hbase090/LogFileParser090.scala
+++ b/hbase/0.90/scala/models/hbase090/LogFileParser090.scala
@@ -11,7 +11,7 @@ import models.hbase.LogFileParser
 
 class LogFileParser090 extends LogFileParser {
 
-  val COMPACTION = Pattern.compile(
+  var COMPACTION = Pattern.compile(
     """^(.*) INFO (.*).HRegion: completed compaction on region (.*\.) after (.*)$""",
     Pattern.MULTILINE
   )
@@ -31,6 +31,10 @@ class LogFileParser090 extends LogFileParser {
 
       functionBlock(region, end, durationMsec)
     }
+  }
+
+  override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
+    COMPACTION = pattern
   }
 
 }

--- a/hbase/0.92/scala/models/hbase092/LogFileParser092.scala
+++ b/hbase/0.92/scala/models/hbase092/LogFileParser092.scala
@@ -11,7 +11,7 @@ import models.hbase.LogFileParser
 
 class LogFileParser092 extends LogFileParser {
 
-  val COMPACTION = Pattern.compile(
+  var COMPACTION = Pattern.compile(
     """^(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)$""",
     Pattern.MULTILINE
   )
@@ -31,6 +31,10 @@ class LogFileParser092 extends LogFileParser {
 
       functionBlock(region, end, durationMsec)
     }
+  }
+
+  override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
+    COMPACTION = pattern
   }
 
 }

--- a/hbase/0.92/scala/models/hbase092/LogFileParser092.scala
+++ b/hbase/0.92/scala/models/hbase092/LogFileParser092.scala
@@ -15,9 +15,9 @@ class LogFileParser092 extends LogFileParser {
     """^(.*) INFO (.*)\.CompactionRequest: completed compaction: regionName=(.*\.), storeName=(.*), fileCount=(.*), fileSize=(.*), priority=(.*), time=(.*); duration=(.*)$""",
     Pattern.MULTILINE
   )
-  val DATE_GROUP = 1
-  val REGION_GROUP = 3
-  val DURATION_GROUP = 9
+  var DATE_GROUP = 1
+  var REGION_GROUP = 3
+  var DURATION_GROUP = 9
 
   override def eachCompaction(logFile: LogFile, functionBlock: (String, Date, Long) => Unit) = {
     val m = COMPACTION.matcher(logFile.tail())
@@ -35,6 +35,18 @@ class LogFileParser092 extends LogFileParser {
 
   override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
     COMPACTION = pattern
+  }
+
+  override def setDateGroupPosition(pos: Int): Unit = {
+    DATE_GROUP = pos
+  }
+
+  override def setRegionGroupPosition(pos: Int): Unit = {
+    REGION_GROUP = pos
+  }
+
+  override def setDurationGroupPosition(pos: Int): Unit = {
+    DURATION_GROUP = pos
   }
 
 }

--- a/hbase/0.96/scala/models.hbase096/LogFileParser096.scala
+++ b/hbase/0.96/scala/models.hbase096/LogFileParser096.scala
@@ -15,9 +15,9 @@ class LogFileParser096 extends LogFileParser {
     """^(.*) INFO (.*).HStore: Completed (.*)compaction of (.*) of (.*\.) into (.*) and took (.*) to execute(.*)$""",
     Pattern.MULTILINE
   )
-  val DATE_GROUP = 1
-  val REGION_GROUP = 5
-  val DURATION_GROUP = 7
+  var DATE_GROUP = 1
+  var REGION_GROUP = 5
+  var DURATION_GROUP = 7
 
   override def eachCompaction(logFile: LogFile, functionBlock: (String, Date, Long) => Unit) = {
     val m = COMPACTION.matcher(logFile.tail())
@@ -35,6 +35,18 @@ class LogFileParser096 extends LogFileParser {
 
   override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
     COMPACTION = pattern
+  }
+  
+  override def setDateGroupPosition(pos: Int): Unit = {
+    DATE_GROUP = pos
+  }
+
+  override def setRegionGroupPosition(pos: Int): Unit = {
+    REGION_GROUP = pos
+  }
+
+  override def setDurationGroupPosition(pos: Int): Unit = {
+    DURATION_GROUP = pos
   }
 
 }

--- a/hbase/0.96/scala/models.hbase096/LogFileParser096.scala
+++ b/hbase/0.96/scala/models.hbase096/LogFileParser096.scala
@@ -11,7 +11,7 @@ import models.hbase.LogFileParser
 
 class LogFileParser096 extends LogFileParser {
 
-  val COMPACTION = Pattern.compile(
+  var COMPACTION = Pattern.compile(
     """^(.*) INFO (.*).HStore: Completed (.*)compaction of (.*) of (.*\.) into (.*) and took (.*) to execute(.*)$""",
     Pattern.MULTILINE
   )
@@ -32,4 +32,9 @@ class LogFileParser096 extends LogFileParser {
       functionBlock(region, end, durationMsec)
     }
   }
+
+  override def setOverrideCopactionRegexPattern(pattern: Pattern): Unit = {
+    COMPACTION = pattern
+  }
+
 }


### PR DESCRIPTION
Hannibal has been already been configured to look for the INFO message containing compaction metrics (with some default regex patterns depending on the version of hbase.)

Some times the INFO message logged might not match with the default regex pattern(maybe its different distribution of base), which would result in you not being able to see the compaction metrics.

if this is the case, you can set the regex pattern via this variable
"logfileParser.overrideCompactionRegexPattern"
